### PR TITLE
Show private events by default

### DIFF
--- a/client/pages/edit/events/[[...id]].tsx
+++ b/client/pages/edit/events/[[...id]].tsx
@@ -107,7 +107,6 @@ const EditEvents = ({
     const [repPopup, setRepPopup] = useState(false);
     const [editAll, setEditAll] = useState('one');
     const [tempData, setTempData] = useState<SubmitData>(null);
-    const [displayError, setDisplayError] = useState(false);
     const {
         handleSubmit,
         setError,
@@ -173,11 +172,6 @@ const EditEvents = ({
         }
     }, [watchLocation]);
 
-    // Set display error if neither public or reservation is selected
-    useEffect(() => {
-        setDisplayError(!watchPublic && noReservationLocations.indexOf(watchLocation) !== -1);
-    }, [watchPublic, watchLocation]);
-
     // When the user submits the form, either create or update the event
     const onSubmit: SubmitHandler<SubmitData> = (data: SubmitData, e) => {
         // Stop reload
@@ -213,11 +207,6 @@ const EditEvents = ({
         if (dayjs(endTime).diff(startTime, 'day') > 100) {
             setPopupEvent(createPopupEvent('Events cannot last more than 100 days!', 3));
             return;
-        }
-
-        // Make sure the events with a location are shown
-        if (data.public && noReservationLocations.indexOf(data.location) !== -1) {
-            setPopupEvent(createPopupEvent('Events that do not have a room reservation cannot be private!', 3));
         }
 
         // Start the upload process display because the reservation might take a bit to find
@@ -530,17 +519,11 @@ const EditEvents = ({
                 <ControlledCheckbox
                     control={control}
                     name="public"
-                    label="Show on Public Calendar (Only check this if you want your event to be shown on the schedule view)"
+                    label="Public Event (Check this if your event is open to everyone)"
                     value={event.publicEvent}
                     setValue={setValue}
                     sx={{ display: 'block' }}
                 />
-                {displayError ? (
-                    <Typography sx={{ color: (theme) => theme.palette.error.main }}>
-                        You may not hide events that do not have a reservation! (Either make the event public or choose
-                        a location)
-                    </Typography>
-                ) : null}
                 {event.id && !duplicate ? null : (
                     <FormBox sx={{ marginTop: 2 }}>
                         <ControlledCheckbox

--- a/client/pages/events/[id].tsx
+++ b/client/pages/events/[id].tsx
@@ -28,10 +28,7 @@ import TitleMeta from '../../src/components/meta/title-meta';
 import RobotBlockMeta from '../../src/components/meta/robot-block-meta';
 
 // Coloring for the event type
-const eventTypeStyle = {
-    color: (theme: Theme) => darkSwitch(theme, theme.palette.grey[600], theme.palette.secondary.main),
-    fontSize: '1.5rem',
-};
+const eventTypeStyle = {};
 
 // Server-side Rendering
 export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
@@ -115,7 +112,21 @@ const EventDisplay = ({ event, error, level, userId }: InferGetServerSidePropsTy
                                     padding: { lg: 1, xs: 0 },
                                 }}
                             >
-                                <Typography sx={eventTypeStyle}>{eventTypeToString(event.type)}</Typography>
+                                <Typography
+                                    sx={{
+                                        color: (theme: Theme) =>
+                                            event.publicEvent
+                                                ? theme.palette.primary.main
+                                                : darkSwitch(
+                                                      theme,
+                                                      theme.palette.secondary.dark,
+                                                      theme.palette.secondary.main
+                                                  ),
+                                        fontSize: '1.5rem',
+                                    }}
+                                >
+                                    {eventTypeToString(event.type) + (event.publicEvent ? ' [Public]' : ' [Private]')}
+                                </Typography>
                                 <Typography variant="h2" component="h1">
                                     {event.name}
                                 </Typography>

--- a/client/pages/events/calendar/[[...date]].tsx
+++ b/client/pages/events/calendar/[[...date]].tsx
@@ -4,10 +4,10 @@ import { useRouter } from 'next/router';
 import { Typography } from '@mui/material';
 import dayjs from 'dayjs';
 import { getAccessLevel } from '../../../src/util/miscUtil';
-import { parsePublicEventList } from '../../../src/util/dataParsing';
+import { parseEventList } from '../../../src/util/dataParsing';
 import { parseDateParams } from '../../../src/util/datetime';
 import { darkSwitch } from '../../../src/util/cssUtil';
-import { getPublicEventListInRange } from '../../../src/api';
+import { getEventListInRange } from '../../../src/api';
 import { AccessLevelEnum } from '../../../src/types/enums';
 
 import Box from '@mui/material/Box';
@@ -57,7 +57,7 @@ export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
 
     // Retrieve the events based on the set dates
     // If there is an error, show an error popup and don't continue
-    let res = await getPublicEventListInRange(startOfPrevMonth.valueOf(), endOfNextMonth.valueOf());
+    let res = await getEventListInRange(startOfPrevMonth.valueOf(), endOfNextMonth.valueOf());
     const error = res.status !== 200;
     const level = await getAccessLevel(ctx);
     return {
@@ -98,7 +98,7 @@ const Calendar = (props: InferGetServerSidePropsType<typeof getServerSideProps>)
         if (props.error) return;
 
         // Parse the fetched events by splitting multi-day events into separate event objects
-        const events = parsePublicEventList(props.activities);
+        const events = parseEventList(props.activities);
 
         // Create the actual list of calendar days by grouping
         // events into their days and adding it to the components list

--- a/client/pages/index.tsx
+++ b/client/pages/index.tsx
@@ -3,9 +3,9 @@ import { GetServerSidePropsContext, InferGetServerSidePropsType } from 'next';
 import type { SxProps, Theme } from '@mui/material';
 import dayjs from 'dayjs';
 import { AccessLevelEnum } from '../src/types/enums';
-import { getPublicEventList } from '../src/api';
+import { getEventList } from '../src/api';
 import { getAccessLevel } from '../src/util/miscUtil';
-import { parsePublicEventList } from '../src/util/dataParsing';
+import { parseEventList } from '../src/util/dataParsing';
 import { isSameDate } from '../src/util/datetime';
 import { darkSwitchGrey } from '../src/util/cssUtil';
 
@@ -20,6 +20,7 @@ import FormLabel from '@mui/material/FormLabel';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import FormGroup from '@mui/material/FormGroup';
 import Checkbox from '@mui/material/Checkbox';
+import Switch from '@mui/material/Switch';
 import FilterListIcon from '@mui/icons-material/FilterList';
 import HomeBase from '../src/components/home/home-base';
 import Loading from '../src/components/shared/loading';
@@ -37,7 +38,7 @@ const listTextFormat = {
 
 // Server-side Rendering
 export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
-    const eventRes = await getPublicEventList();
+    const eventRes = await getEventList();
     const level = await getAccessLevel(ctx);
 
     // Return error if bad data
@@ -47,7 +48,7 @@ export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
     // that do not start on or after the current date
     const startOfToday = dayjs().startOf('day').valueOf();
     const filteredList = eventRes.data.sort((a, b) => a.start - b.start).filter((e) => e.start >= startOfToday);
-    const parsedEventList = parsePublicEventList(filteredList);
+    const parsedEventList = parseEventList(filteredList);
     return {
         props: { eventList: parsedEventList, error: false, level },
     };
@@ -58,6 +59,7 @@ const Home = ({ eventList, error, level }: InferGetServerSidePropsType<typeof ge
         <Loading sx={{ marginBottom: 4 }} />
     );
     const [anchorEl, setAnchorEl] = useState(null);
+    const [showPrivate, setShowPrivate] = useState(true);
     const [filters, setFilters] = useState({
         event: false,
         ga: false,
@@ -148,6 +150,11 @@ const Home = ({ eventList, error, level }: InferGetServerSidePropsType<typeof ge
         setFilters({ ...filters, [event.target.name]: event.target.checked });
     };
 
+    // Change showPrivate when switch state is changed
+    const handlePrivateChange = (event) => {
+        setShowPrivate(event.target.checked);
+    }
+
     // Show error message if errored
     if (error) {
         return (
@@ -190,6 +197,9 @@ const Home = ({ eventList, error, level }: InferGetServerSidePropsType<typeof ge
                     >
                         Filter Events by Type
                     </Typography>
+                    <FormGroup>
+                        <FormControlLabel control={<Switch defaultChecked />} checked={showPrivate} onChange={handlePrivateChange} label="Show Private Events" />
+                    </FormGroup>
                 </Box>
                 {eventComponentList}
             </Container>

--- a/client/pages/index.tsx
+++ b/client/pages/index.tsx
@@ -88,10 +88,14 @@ const Home = ({ eventList, error, level }: InferGetServerSidePropsType<typeof ge
 
         // Filter the event list
         const filteredEventList = eventList.filter((event) => {
-            // If no filters selected, return true
-            if (!(filters.event || filters.ga || filters.meeting || filters.volunteering || filters.other)) return true;
+            // If no filters selected, ignore filter field and check for private event
+            if (!(filters.event || filters.ga || filters.meeting || filters.volunteering || filters.other)) {
+                return showPrivate || event.publicEvent;
+            }
 
-            return filters[event.type];
+            // Check if event matches filter
+            // AND isn't private if we want to hide private events
+            return filters[event.type] && (showPrivate || event.publicEvent);
         });
 
         // Return if the list is empty
@@ -132,7 +136,7 @@ const Home = ({ eventList, error, level }: InferGetServerSidePropsType<typeof ge
 
         // Display list
         setEventComponentList(groupedComponents);
-    }, [eventList, filters]);
+    }, [eventList, filters, showPrivate]);
 
     // Open the popup element on click
     // The setAchorEl is used for the Popover component
@@ -153,7 +157,7 @@ const Home = ({ eventList, error, level }: InferGetServerSidePropsType<typeof ge
     // Change showPrivate when switch state is changed
     const handlePrivateChange = (event) => {
         setShowPrivate(event.target.checked);
-    }
+    };
 
     // Show error message if errored
     if (error) {
@@ -179,7 +183,7 @@ const Home = ({ eventList, error, level }: InferGetServerSidePropsType<typeof ge
                 <AddButton
                     color="primary"
                     label="Event"
-                    path={level < AccessLevelEnum.STANDARD ? "/profile?prev=/edit/events" : "/edit/events"}
+                    path={level < AccessLevelEnum.STANDARD ? '/profile?prev=/edit/events' : '/edit/events'}
                 />
                 <Box width="100%" marginBottom={2} display="flex" alignItems="center">
                     <Tooltip title="Filters">
@@ -198,7 +202,12 @@ const Home = ({ eventList, error, level }: InferGetServerSidePropsType<typeof ge
                         Filter Events by Type
                     </Typography>
                     <FormGroup>
-                        <FormControlLabel control={<Switch defaultChecked />} checked={showPrivate} onChange={handlePrivateChange} label="Show Private Events" />
+                        <FormControlLabel
+                            control={<Switch />}
+                            checked={showPrivate}
+                            onChange={handlePrivateChange}
+                            label="Show Private Events"
+                        />
                     </FormGroup>
                 </Box>
                 {eventComponentList}

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -138,7 +138,7 @@ function createHeaders(auth: boolean, json: boolean): Headers {
 /**
  * Gets the list of public events.
  */
-export async function getPublicEventList(): Promise<ListFetchResponse<CalEvent>> {
+export async function getEventList(): Promise<ListFetchResponse<CalEvent>> {
     return getRequest('/events') as Promise<ListFetchResponse<CalEvent>>;
 }
 
@@ -148,7 +148,7 @@ export async function getPublicEventList(): Promise<ListFetchResponse<CalEvent>>
  * @param start Starting time to get events from
  * @param end Ending time to get events to
  */
-export async function getPublicEventListInRange(start: number, end: number): Promise<ListFetchResponse<CalEvent>> {
+export async function getEventListInRange(start: number, end: number): Promise<ListFetchResponse<CalEvent>> {
     return getRequest(`/events?start=${start}&end=${end}`) as Promise<ListFetchResponse<CalEvent>>;
 }
 

--- a/client/src/components/calendar/calendar-event.tsx
+++ b/client/src/components/calendar/calendar-event.tsx
@@ -7,6 +7,7 @@ import { darkSwitch, darkSwitchGrey } from '../../util/cssUtil';
 import ListItem from '@mui/material/ListItem';
 import Typography from '@mui/material/Typography';
 import Link from '../shared/Link';
+import StyledSpan from '../shared/styled-span';
 
 interface CalendarEventProps {
     /** Event object to display */
@@ -61,6 +62,14 @@ const CalendarEvent = (props: CalendarEventProps) => {
                         fontSize: { lg: '0.85rem', xs: '0.65rem' },
                     }}
                 >
+                    <StyledSpan
+                        sx={{
+                            color: (theme: Theme) =>
+                                darkSwitch(theme, theme.palette.secondary.dark, theme.palette.secondary.main),
+                        }}
+                    >
+                        {!props.event.publicEvent ? '[p] ' : ''}
+                    </StyledSpan>
                     {props.event.name}
                 </Typography>
             </Link>

--- a/client/src/components/home/event-entry.tsx
+++ b/client/src/components/home/event-entry.tsx
@@ -60,6 +60,15 @@ const EventEntry = ({ event }: EventEntryProps) => {
                             fontSize: { lg: '1.25rem', xs: '1rem' },
                         }}
                     >
+                        <StyledSpan
+                            sx={{
+                                color: (theme: Theme) =>
+                                    darkSwitch(theme, theme.palette.secondary.dark, theme.palette.secondary.main),
+                                fontSize: { lg: '1rem', xs: '0.75rem' },
+                            }}
+                        >
+                            {!event.publicEvent ? '[Private] ' : ''}
+                        </StyledSpan>
                         {event.name}
                     </Typography>
                     <Typography

--- a/client/src/components/home/home-drawer-list.tsx
+++ b/client/src/components/home/home-drawer-list.tsx
@@ -37,7 +37,7 @@ const HomeDrawerList = () => {
     useEffect(() => {
         setLinkComponents(
             links.map((link) => (
-                <ListItemButton component="a" href={link.url} target="_blank">
+                <ListItemButton component="a" href={link.url} target="_blank" key={link.url}>
                     <MaterialSymbol icon={link.icon} />
                     <ListItemText primary={link.name} />
                 </ListItemButton>

--- a/client/src/util/dataParsing.tsx
+++ b/client/src/util/dataParsing.tsx
@@ -13,7 +13,7 @@ import { isNotMidnight } from './datetime';
  * @returns The event list with split up events across days
  */
 
-export function parsePublicEventList(eventList: CalEvent[]): CalEvent[] {
+export function parseEventList(eventList: CalEvent[]): CalEvent[] {
     const outputList = [];
     eventList.forEach((a) => {
         // Simply return the event if it does not span across multiple days

--- a/server/routes/eventsRouter.ts
+++ b/server/routes/eventsRouter.ts
@@ -14,7 +14,7 @@ const router = express.Router();
 /**
  * GET /events
  *
- * Sends a list of public events
+ * Sends a list of all events
  *
  * Query parameters:
  * - start:      Starting time to get events from (default: Current Day Start)
@@ -33,20 +33,18 @@ router.get('/', async (req: Request, res: Response) => {
     const end = Number(req.query.end) || null;
 
     if (!end) {
-        const activities = await Event.find({
-            publicEvent: true,
+        const events = await Event.find({
             start: { $gte: dayjs(start).startOf('day').subtract(1, 'day') },
         }).exec();
-        res.send(activities);
+        res.send(events);
     } else {
-        const activities = await Event.find({
-            publicEvent: true,
+        const events = await Event.find({
             start: {
                 $gte: dayjs(start).startOf('day').subtract(1, 'day'),
                 $lte: dayjs(end).endOf('day').add(1, 'day'),
             },
         }).exec();
-        res.send(activities);
+        res.send(events);
     }
 });
 


### PR DESCRIPTION
### Description

* Shows private events by default on the schedule page
* Add toggle to toggle them on/off
* Also shows on the calendar page
* Edit event no longer warns about the invalid state of both private event + no reservation
* Fixed some random key issue

### Fixes #567 

### Type of change

Delete options that do not apply:

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

### Checklist

- [x] My code follows the [coding conventions](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md#computer-coding-conventions) AND I have formatted with the prettier VSCode extension or `yarn format`
- [x] All existing functionality (if a non-breaking change) still works as it should
- [x] I have assigned at least one person to review my pull request
