### PR TITLE
Fixed bug with repeating events not deleting correctly

### DIFF
--- a/client/src/components/shared/delete-button.tsx
+++ b/client/src/components/shared/delete-button.tsx
@@ -67,7 +67,7 @@ const DeleteButton = (props: DeleteButtonProps) => {
         let res = null;
         if (props.resource === 'events') {
             res =
-                props.isRepeating && repDelete
+                props.isRepeating && repDelete === 'all'
                     ? await deleteRepeatingEvents(props.repeatingId)
                     : await deleteEvent(props.id);
         } else if (props.resource === 'clubs') {
@@ -91,7 +91,7 @@ const DeleteButton = (props: DeleteButtonProps) => {
 
     const handleRepeatingRadioChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         setRepDelete(e.currentTarget.value);
-    }
+    };
 
     return (
         <React.Fragment>


### PR DESCRIPTION
### Description

The "delete one repeating instance" option wasn't working because it wasn't calling the right endpoint due to the fact that I forgot how radio buttons' values work TT

### Type of change

Delete options that do not apply:

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [X] My code follows the [coding conventions](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md#computer-coding-conventions) AND I have formatted with the prettier VSCode extension or `yarn format`
- [X] All existing functionality (if a non-breaking change) still works as it should
- [X] I have assigned at least one person to review my pull request
