### PR TITLE
Fix github action missing version

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -13,7 +13,7 @@ jobs:
               uses: actions/checkout@v5
 
             - name: Use NodeJS 20
-              uses: actions/setup-node@v5
+              uses: actions/setup-node@v4
               with:
                   node-version: '20'
 


### PR DESCRIPTION
### Description

Error: Unable to resolve action `actions/setup-node@v5`, unable to find version `v5`.

This fixes that by downgrading to v4.

### Fixes https://github.com/tams-cso/tams-club-cal/actions/runs/17422720433/job/49464069975

### Type of change

Delete options that do not apply:

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [X] My code follows the [coding conventions](https://github.com/MichaelZhao21/tams-club-cal/blob/master/CONTRIBUTING.md#computer-coding-conventions) AND I have formatted with the prettier VSCode extension or `yarn format`
- [X] All existing functionality (if a non-breaking change) still works as it should
- [X] I have assigned at least one person to review my pull request
